### PR TITLE
Pass in exchange code as arg or use consolePrompt if arg undefined

### DIFF
--- a/example-test/generatedeviceauth.js
+++ b/example-test/generatedeviceauth.js
@@ -27,8 +27,9 @@ const client = new Client({
   // In the JSON file on disk
 
   // This is where the magic happen
+  // If you don't pass your exchange code as an argument client.createDeviceAuthFromExchangeCode(), you will be prompted in the command line after starting the project to enter your exchange code
   console.log('Success creation of device auth',
-    await client.createDeviceAuthFromExchangeCode());
+    await client.createDeviceAuthFromExchangeCode(process.env.EXCHANGE_CODE));
 
   // Perform the login process of the "client"
   console.log('Success login with created device auth',

--- a/src/Client/index.js
+++ b/src/Client/index.js
@@ -33,8 +33,8 @@ module.exports = class Client {
    * Creates and saves a device auth
    * Must perform login afterwards
    */
-  async createDeviceAuthFromExchangeCode() {
-    const code = await Utils.consolePrompt('To generate device auth, please provide an exchange code: ');
+  async createDeviceAuthFromExchangeCode(exchangeCode) {
+    const code = exchangeCode || await Utils.consolePrompt('To generate device auth, please provide an exchange code: ');
     await this.requester.sendGet(false, Endpoints.CSRF_TOKEN);
     const xsrf = this.requester.jar.getCookies(Endpoints.CSRF_TOKEN).find((x) => x.key === 'XSRF-TOKEN');
     if (!xsrf) return { error: 'Failed querying CSRF endpoint with a valid response of XSRF-TOKEN' };


### PR DESCRIPTION
I wanted to be able to setup my exchange code as an environment variable instead of entering it in the console and I thought other people may want that functionality as well.  If they don't include an argument in createDeviceAuthFromExchangeCode() then it will still prompt them to enter their exchange code in the terminal 